### PR TITLE
[Fix] Repair field mapping for deeply embedded docs

### DIFF
--- a/src/api/lib/fields/lib/field.js
+++ b/src/api/lib/fields/lib/field.js
@@ -188,7 +188,7 @@ var Field = NOOT.Object.extend({
    * @return {String}
    */
   removeWildcardsFromPath: function (path) {
-    return path.replace(new RegExp(NOOT.toRegExpString('.' + this.WILDCARD + '.')), '.');
+    return path.replace(new RegExp(NOOT.toRegExpString('.' + this.WILDCARD + '.'), 'g'), '.');
   },
 
   /**
@@ -199,7 +199,7 @@ var Field = NOOT.Object.extend({
    * @return {String}
    */
   replaceReferenceWithWildcard: function (path) {
-    return path.replace(/\.\d+\./, '.' + this.WILDCARD + '.');
+    return path.replace(/\.\d+\./g, '.' + this.WILDCARD + '.');
   }
 
 });

--- a/src/api/lib/resources/classes/mongoose-resource.js
+++ b/src/api/lib/resources/classes/mongoose-resource.js
@@ -212,7 +212,7 @@ var MongooseResource = MongoResource.extend({
       var mongoosePath = paths[pathName];
 
       if (mongoosePath.schema) {
-        _.extend(ret, this.getFields(mongoosePath.schema, Field.appendWildcardToPath(pathName)));
+        _.extend(ret, this.getFields(mongoosePath.schema, Field.appendWildcardToPath(parentPath + pathName)));
       } else {
         ret[parentPath + pathName] = this.constructor.toAPIField(paths[pathName], this, parentPath);
       }

--- a/src/api/lib/resources/lib/resource.js
+++ b/src/api/lib/resources/lib/resource.js
@@ -348,7 +348,7 @@ var Resource = NOOT.Object.extend(Authable).extend(Queryable).extend({
     body.forEach(function(item) {
       Object.keys(flatten(item)).forEach(function(key) {
         var wildcarded = Field.replaceReferenceWithWildcard(key);
-        var unaddressed = key.replace(/\.\d+$/, '');
+        var unaddressed = Field.replaceReferenceWithWildcard(key).replace(/\.\d+$/, '');
         var isValidField = _.contains(writable, key) ||
           _.contains(writable, wildcarded) ||
           _.contains(writable, unaddressed);

--- a/test/api/complete.test.js
+++ b/test/api/complete.test.js
@@ -50,7 +50,7 @@ UserSchema = Schema.extend({
     oldEnough: { type: Boolean, default: false },
     hobbies: [{ type: String, default: function() { return []; } }],
     secondaryEmails: [{ value: { type: String, required: true }, created: { type: Date, default: Date.now() } }],
-    nested: [{ values: [{type: Number }], created: { type: Date, default: Date.now() } }]
+    nested: [{ values: [{type: Number }], nestedOfNested: [{ values: [String] }], created: { type: Date, default: Date.now() } }]
   }
 });
 
@@ -373,7 +373,11 @@ describe('NOOT.API - Complete test', function() {
       name: { first: 'deeper', last: 'test' },
       password: 'pw',
       email: 'my@email.com',
-      nested: [{ values: [0, 1, 2]}, { values: [3, 4, 5] }]
+      nested: [
+        { values: [0, 1, 2]},
+        { values: [3, 4, 5] },
+        { values: [6, 7, 8], nestedOfNested: [{ values: [9, 10] }, { values: [11, 12] }] }
+      ]
     };
 
     return supertest(app)

--- a/test/api/complete.test.js
+++ b/test/api/complete.test.js
@@ -49,7 +49,8 @@ UserSchema = Schema.extend({
     blogs: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Blog' }],
     oldEnough: { type: Boolean, default: false },
     hobbies: [{ type: String, default: function() { return []; } }],
-    secondaryEmails: [{ value: { type: String, required: true }, created: { type: Date, default: Date.now() } }]
+    secondaryEmails: [{ value: { type: String, required: true }, created: { type: Date, default: Date.now() } }],
+    nested: [{ values: [{type: Number }], created: { type: Date, default: Date.now() } }]
   }
 });
 
@@ -364,6 +365,25 @@ describe('NOOT.API - Complete test', function() {
           user.age.should.eql(29);
           return done();
         });
+      });
+  });
+
+  it('should create user with nested documents', function(done) {
+    var nested = {
+      name: { first: 'deeper', last: 'test' },
+      password: 'pw',
+      email: 'my@email.com',
+      nested: [{ values: [0, 1, 2]}, { values: [3, 4, 5] }]
+    };
+
+    return supertest(app)
+      .post('/private/users/register')
+      .send(nested)
+      .expect(201, function(err, res) {
+        if (err) return done(err);
+        var body = res.body.data;
+        body.nested[0].values.should.have.length(3);
+        return done();
       });
   });
 


### PR DESCRIPTION
- use wildcard replacing globally
- resolve the path splitting for deeply embedded fields